### PR TITLE
fix(evidence): normalize captured_at for naive timestamp columns

### DIFF
--- a/schema/work_project/evidence.py
+++ b/schema/work_project/evidence.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Any
 
@@ -61,6 +61,16 @@ class WorkProjectEvidenceRequest(BaseModel):
     @classmethod
     def normalize_text(cls, value: Any) -> Any:
         return value.strip() if isinstance(value, str) else value
+
+    @field_validator("captured_at", mode="after")
+    @classmethod
+    def normalize_captured_at(cls, value: datetime) -> datetime:
+        # Postgres stores captured_at as TIMESTAMP WITHOUT TIME ZONE.
+        # Tool/JSON ISO values with Z or offsets parse as aware datetimes;
+        # asyncpg rejects those against a naive column.
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
 
     @model_validator(mode="after")
     def validate_hash(self) -> "WorkProjectEvidenceRequest":


### PR DESCRIPTION
### 问题描述

Agent 调用 `record_work_project_evidence` 写入 WorkProject 证据时，会抛出 `asyncpg.DataError`，证据无法入库。WorkItem 因此一直停在 `blocked`，即使沙箱里已经保存了原始数据和 SHA-256。

复现时的错误类似：

```text
DataError: invalid input for query argument $1: datetime.datetime(..., tzinfo=TzInfo(0))
can't subtract offset-naive and offset-aware datetimes
```

该问题与提交格式无关：只要 `captured_at` 带 `Z` 或时区偏移（Agent / OpenAI 工具调用的常见写法），就会失败。

### 原因分析

1. `work_project_evidence.captured_at` 在 Postgres 中的类型是 `TIMESTAMP WITHOUT TIME ZONE`（naive）。
2. 请求模型 `WorkProjectEvidenceRequest.captured_at` 是裸 `datetime`。Pydantic v2 解析 ISO-8601 时：
   - `"2026-08-22T12:00:00Z"` / `"+00:00"` → timezone-aware
   - `"2026-08-22T12:00:00"` → naive
3. Agent 工具层通常会带 `Z` 或偏移。解析后的 aware datetime 被原样交给 SQLAlchemy / asyncpg。
4. asyncpg 向 naive `timestamp` 列绑定 aware datetime 时直接报 `DataError`，插入回滚。
5. `created_at` 等字段由服务端 `datetime.now()` 生成（naive），所以只有 Agent 传入的 `captured_at` 会踩中这条路径。

### 建议修复方案

在 `schema/work_project/evidence.py` 的 `WorkProjectEvidenceRequest` 上增加 `captured_at` 校验：若带时区，先转到 UTC 再去掉 `tzinfo`；已经是 naive 的值保持不变。这样工具调用、HTTP 入口都会走同一条规范化路径。

```python
@field_validator("captured_at", mode="after")
@classmethod
def normalize_captured_at(cls, value: datetime) -> datetime:
    # Postgres stores captured_at as TIMESTAMP WITHOUT TIME ZONE.
    # Tool/JSON ISO values with Z or offsets parse as aware datetimes;
    # asyncpg rejects those against a naive column.
    if value.tzinfo is None:
        return value
    return value.astimezone(timezone.utc).replace(tzinfo=None)
```

已在本地对 `Z`、`+00:00`、`+08:00` 以及不带时区的字符串做过绑定校验，规范化后均可写入 `timestamp` 列。