### PR TITLE
fix(playground): reduce GPU load and restore Work Project sidebar styles

### DIFF
--- a/web/src/app/styles/admin.css
+++ b/web/src/app/styles/admin.css
@@ -11,7 +11,7 @@
   min-height: 0;
   overflow: hidden;
   color: var(--z-text);
-  background: transparent;
+  background: var(--z-bg);
 }
 
 .admin-sidebar {
@@ -336,7 +336,7 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: transparent;
+  background: var(--z-bg);
 }
 
 .admin-content-viewport {

--- a/web/src/app/styles/base.css
+++ b/web/src/app/styles/base.css
@@ -91,13 +91,9 @@ body {
   background-image:
     linear-gradient(rgba(156, 199, 203, 0.035) 1px, transparent 1px),
     linear-gradient(90deg, rgba(156, 199, 203, 0.035) 1px, transparent 1px),
-    linear-gradient(118deg, transparent 16%, rgba(217, 45, 58, 0.13) 38%, transparent 58%),
-    linear-gradient(62deg, transparent 34%, rgba(125, 219, 211, 0.09) 56%, transparent 76%),
     linear-gradient(145deg, var(--z-bg) 0%, var(--z-bg-mid) 48%, var(--z-bg-deep) 100%);
-  background-position: 0 0, 0 0, 0% 34%, 100% 66%, center;
-  background-size: 52px 52px, 52px 52px, 180% 180%, 180% 180%, cover;
-  background-attachment: fixed;
-  animation: globalBackdropDrift 26s ease-in-out infinite alternate;
+  background-position: 0 0, 0 0, center;
+  background-size: 52px 52px, 52px 52px, cover;
   --semi-color-bg-0: var(--z-bg);
   --semi-color-bg-1: var(--z-surface-strong);
   --semi-color-bg-2: var(--z-surface-strong);

--- a/web/src/app/styles/markdown.css
+++ b/web/src/app/styles/markdown.css
@@ -164,6 +164,11 @@
   margin: 0 auto;
 }
 
+.markdown-content .mermaid-diagram svg * {
+  animation: none !important;
+  transition: none !important;
+}
+
 .markdown-content .mermaid-diagram[aria-busy="true"] {
   min-height: 96px;
   background: var(--z-surface-muted);

--- a/web/src/app/styles/playground-layout.css
+++ b/web/src/app/styles/playground-layout.css
@@ -5,7 +5,7 @@
   min-height: 0;
   overflow: hidden;
   color: var(--z-text);
-  background: transparent;
+  background: var(--z-bg);
 }
 
 .session-list {
@@ -87,6 +87,8 @@
   color: inherit;
   background: transparent;
   border: 0;
+  appearance: none;
+  -webkit-appearance: none;
   cursor: pointer;
   text-align: left;
 }
@@ -148,6 +150,8 @@
   color: var(--z-text-subtle);
   background: transparent;
   border: 0;
+  appearance: none;
+  -webkit-appearance: none;
   cursor: pointer;
   font-size: 12px;
   text-align: left;

--- a/web/src/app/styles/playground-subagent.css
+++ b/web/src/app/styles/playground-subagent.css
@@ -8,7 +8,6 @@
   transition:
     opacity var(--motion-normal) var(--ease-standard),
     transform var(--motion-slow) var(--ease-emphasized);
-  will-change: opacity, transform;
 }
 
 .subagent-side-panel-open {

--- a/web/src/app/styles/playground-transcript.css
+++ b/web/src/app/styles/playground-transcript.css
@@ -269,21 +269,16 @@
   height: 26px;
   pointer-events: none;
   z-index: 1;
-  background: var(--z-surface);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
 }
 
 .thinking-fade-top {
   top: 0;
-  -webkit-mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, 0) 100%);
-  mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(180deg, var(--z-surface) 0%, rgba(0, 0, 0, 0) 100%);
 }
 
 .thinking-fade-bottom {
   bottom: 0;
-  -webkit-mask-image: linear-gradient(0deg, #000 0%, rgba(0, 0, 0, 0) 100%);
-  mask-image: linear-gradient(0deg, #000 0%, rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(0deg, var(--z-surface) 0%, rgba(0, 0, 0, 0) 100%);
 }
 
 .execution-row {

--- a/web/src/features/playground/SessionList.tsx
+++ b/web/src/features/playground/SessionList.tsx
@@ -20,6 +20,7 @@ import { mergeByKey } from "../../shared/lib/array";
 import { cx } from "../../shared/lib/className";
 import { UI_TEXT } from "../../shared/lib/uiText";
 import { WorkProjectInfoModal } from "../work-projects/WorkProjectInfoModal";
+import "../../app/styles/playground-layout.css";
 
 const PROJECT_REFRESH_INTERVAL_MS = 5_000;
 

--- a/web/src/features/playground/Transcript.tsx
+++ b/web/src/features/playground/Transcript.tsx
@@ -140,7 +140,8 @@ const MarkdownText = memo(function MarkdownText({ text, streaming }: { text: str
       return;
     }
     const timer = setInterval(() => {
-      setRenderText(latestTextRef.current);
+      const next = latestTextRef.current;
+      setRenderText((current) => (current === next ? current : next));
     }, STREAM_RENDER_INTERVAL_MS);
     return () => {
       clearInterval(timer);
@@ -157,7 +158,7 @@ const MarkdownText = memo(function MarkdownText({ text, streaming }: { text: str
     [renderText, streaming],
   );
   if (!renderText && !streaming) return null;
-  return <MarkdownContent className="agent-text" content={markdown} mode="document" mermaid />;
+  return <MarkdownContent className="agent-text" content={markdown} mode="document" mermaid={!streaming} />;
 });
 
 function ThinkingGroup({

--- a/web/src/shared/components/MermaidDiagram.tsx
+++ b/web/src/shared/components/MermaidDiagram.tsx
@@ -6,6 +6,8 @@ mermaid.initialize({
   securityLevel: "strict",
   theme: "base",
   suppressErrorRendering: true,
+  maxTextSize: 50_000,
+  flowchart: { htmlLabels: true, useMaxWidth: true },
   themeVariables: {
     primaryColor: "#161f2e",
     primaryTextColor: "#f8fafc",


### PR DESCRIPTION
### 问题描述

1. 浏览器停留在 Playground（`/playground`）时，GPU 占用和温度会持续上升，风扇狂转；切到其它后台页面会立刻好转，再切回来过一会儿又开始。
2. 左侧 SessionList 里的 Work Project 行（例如项目名那一行）会退化成 macOS 原生白底黑字按钮，原有的深色主题样式丢失。

### 原因分析

**GPU / 风扇**

1. `body` 使用了 5 层网格/渐变背景，并加上 `background-attachment: fixed` 与 `animation: globalBackdropDrift ... infinite`，合成器每一帧都在重绘整页背景。
2. `.admin-shell`、`.admin-content`、`.playground-shell` 背景都是 `transparent`。Playground 又是 `admin-content-viewport-fixed` 全屏固定视口，等于整块对话区都叠在这块会动的背景上。
3. 思考条 `.thinking-fade` 还对滚动中的文本做了 `backdrop-filter: blur(12px)`，长会话里会持续做实时模糊合成。
4. 流式输出时 `MarkdownText` 大约每 80ms 重绘一次整段 Markdown，且 `mermaid` 始终开启。同一条消息里已经闭合的 mermaid 代码块会随着后续 token 反复 `mermaid.render()`，图越多 GPU 越热。

**侧栏白按钮**

1. `SessionList` 挂在 `AdminLayout` 侧栏，始终存在。
2. 它用的 `.session-row-main` 等样式却写在 `playground-layout.css` 里，只被 `PlaygroundPage` import。Vite 会把这份 CSS 打进 Playground 分包。
3. 分包未加载、缓存错位或从 Playground 离开导致 CSS 被卸掉时，项目名那一行的原生 `<button>` 就会露出系统默认外观（白底圆角按钮）。右侧 Semi UI 图标按钮不受影响，所以看起来像「只有 Work Project 样式没了」。

### 建议修复方案

**1. 停止全屏背景动画，并把壳层涂不透明**

`web/src/app/styles/base.css`：去掉 `globalBackdropDrift` 和 `background-attachment: fixed`，保留静态网格。

`admin.css` / `playground-layout.css`：`.admin-shell`、`.admin-content`、`.playground-shell` 使用 `background: var(--z-bg)`，不再透出底层动画。

**2. 思考条改用静态渐变，流式阶段不渲染 Mermaid**

```css
.thinking-fade-top {
  top: 0;
  background: linear-gradient(180deg, var(--z-surface) 0%, rgba(0, 0, 0, 0) 100%);
}
```

```tsx
return <MarkdownContent className="agent-text" content={markdown} mode="document" mermaid={!streaming} />;
```

流式结束后再画一次图；并为 mermaid SVG 关闭 CSS animation。

**3. 让 SessionList 自己带上布局样式，并关掉系统按钮外观**

```tsx
import "../../app/styles/playground-layout.css";
```

```css
.session-row-main {
  background: transparent;
  border: 0;
  appearance: none;
  -webkit-appearance: none;
}
```

这样侧栏样式不再依赖 Playground 页面分包，Work Project 行会保持深色主题。